### PR TITLE
Fixed bug when 7 bits would be interpreted as a 0

### DIFF
--- a/DHT22RinusW.py
+++ b/DHT22RinusW.py
@@ -41,7 +41,7 @@ def decode(inp):
     for i in range(len(res)):
         for v in bits[i*8:(i+1)*8]:   #process next 8 bit
             res[i] = res[i]<<1  ##shift byte one place to left
-            if v > 7:                   #  less than 7 '1's is a zero, more than 7 1's in the sequence is a one
+            if v >= 7:                   #  less than 7 '1's is a zero, 7 or more 1's in the sequence is a one
                 res[i] = res[i]+1  ##and add 1 if lsb is 1
             # print ('res',  i,  res[i])
 


### PR DESCRIPTION
When 7 bits was found, it was interpreted as a 0, not a 1.  The data
collected from the DHT22, when using LoPy on firmware 1.7.9.b3, usually comes back at 7 bits for a value of ‘1’.